### PR TITLE
User can specify sender id

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ $notify = new MNotify();
 $notify->sendQuickSMS(['0542092800', '0507455860'], 'Hello, this is a quick reminder.');
 ```
 
+#### Quick SMS with Named Sender ID (Override MNOTIFY_SENDER_ID in the dotenv file)
+```php
+use Arhinful\LaravelMnotify\MNotify;
+
+$notify = new MNotify('Your Sender Name');
+$notify->sendQuickSMS(['0542092800', '0507455860'], 'Hello, this is a quick reminder with a named sender ID.');
+```
+
 #### SMS from Template
 ```php
 $notify = new MNotify();

--- a/src/MNotify.php
+++ b/src/MNotify.php
@@ -58,10 +58,10 @@ class MNotify
     private $message_template;
     private $groups;
 
-    public function __construct()
+    public function __construct(?string $senderId = null)
     {
         $this->apiKey = env('MNOTIFY_KEY', '');
-        $this->sender = env('MNOTIFY_SENDER_ID', '');
+        $this->sender = $senderId ?? env('MNOTIFY_SENDER_ID', '');
         $this->isSchedule = false;
     }
 


### PR DESCRIPTION
Usage


# You have a specific sender ID to use 
$optionalSenderId = "New Sender"; // the sender id user wants to use
$mnotify = new Mnotify($optionalSenderId ); // add the senderId as an argument

# You want to use the default configuration
$mnotify = new Mnotify();
